### PR TITLE
feat(web): refine portions inventory sorting and responsive card layout

### DIFF
--- a/apps/web/components.json
+++ b/apps/web/components.json
@@ -19,7 +19,5 @@
     "lib": "@/lib",
     "hooks": "@/hooks"
   },
-  "menuColor": "default",
-  "menuAccent": "subtle",
   "registries": {}
 }

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -1,0 +1,184 @@
+import * as React from "react";
+import { Select as SelectPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react";
+
+function Select({ ...props }: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />;
+}
+
+function SelectGroup({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return (
+    <SelectPrimitive.Group
+      data-slot="select-group"
+      className={cn("scroll-my-1 p-1", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectValue({ ...props }: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />;
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default";
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-1.5 rounded-4xl border border-input bg-input/50 px-3 py-2 text-sm whitespace-nowrap transition-colors outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-[3px] aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  );
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "item-aligned",
+  align = "center",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        data-align-trigger={position === "item-aligned"}
+        className={cn(
+          "relative z-50 max-h-(--radix-select-content-available-height) min-w-36 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-2xl bg-popover text-popover-foreground shadow-2xl ring-1 ring-foreground/5 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className,
+        )}
+        position={position}
+        side="bottom"
+        align={align}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          data-position={position}
+          className={cn(
+            "data-[position=popper]:h-(--radix-select-trigger-height) data-[position=popper]:w-full data-[position=popper]:min-w-(--radix-select-trigger-width)",
+            position === "popper" && "",
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  );
+}
+
+function SelectLabel({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("px-3 py-2.5 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-2.5 py-2 pr-8 pl-3 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className,
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="pointer-events-none" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  );
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border/50", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "z-10 flex cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      <ChevronUpIcon />
+    </SelectPrimitive.ScrollUpButton>
+  );
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "z-10 flex cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      <ChevronDownIcon />
+    </SelectPrimitive.ScrollDownButton>
+  );
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+};

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -76,7 +76,6 @@ function SelectContent({
           data-position={position}
           className={cn(
             "data-[position=popper]:h-(--radix-select-trigger-height) data-[position=popper]:w-full data-[position=popper]:min-w-(--radix-select-trigger-width)",
-            position === "popper" && "",
           )}
         >
           {children}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -23,7 +23,7 @@
   --foreground: #35322a;
   --card: #ffffff;
   --card-foreground: #35322a;
-  --popover: rgb(252 251 247 / 80%);
+  --popover: rgb(252 251 247 / 100%);
   --popover-foreground: #35322a;
   --primary: #526447;
   --primary-foreground: #fef9f1;
@@ -39,7 +39,7 @@
   --accent-foreground: #42384c;
   --destructive: oklch(0.577 0.245 27.325);
   --border: rgb(53 50 42 / 15%);
-  --input: #f4f0e8;
+  --input: #e8e0d4;
   --ring: rgb(82 100 71 / 40%);
   --chart-1: oklch(0.868 0.007 39.5);
   --chart-2: oklch(0.547 0.021 43.1);

--- a/apps/web/src/queries/portion.ts
+++ b/apps/web/src/queries/portion.ts
@@ -1,18 +1,31 @@
 import { mutationOptions, queryOptions } from "@tanstack/react-query";
-import { apiClient, type CreatePortionBody, type UpdatePortionBody } from "@cube-prep/api-client";
+import {
+  apiClient,
+  type CreatePortionBody,
+  type paths,
+  type UpdatePortionBody,
+} from "@cube-prep/api-client";
 
-export const portionsQueryOptions = queryOptions({
-  queryKey: ["portions"],
-  queryFn: async () => {
-    const { data } = await apiClient.GET("/portions");
+type ListPortionsQuery = NonNullable<paths["/portions"]["get"]["parameters"]["query"]>;
+export const portionsQueryKey = ["portions"] as const;
 
-    if (!data) {
-      throw new Error("Could not load portions.");
-    }
+export const portionsQueryOptions = (query?: ListPortionsQuery) =>
+  queryOptions({
+    queryKey: [...portionsQueryKey, query?.sort, query?.order],
+    queryFn: async () => {
+      const { data } = await apiClient.GET("/portions", {
+        params: {
+          query,
+        },
+      });
 
-    return data;
-  },
-});
+      if (!data) {
+        throw new Error("Could not load portions.");
+      }
+
+      return data;
+    },
+  });
 
 export const portionsMutationOptions = mutationOptions({
   mutationKey: ["create-portion"],

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -5,5 +5,5 @@ export const Route = createFileRoute("/")({
 });
 
 function HomeRedirect() {
-  return <Navigate to="/portions" />;
+  return <Navigate to="/portions" search={{ sort: undefined, order: undefined }} />;
 }

--- a/apps/web/src/routes/portions/$portionId/edit.tsx
+++ b/apps/web/src/routes/portions/$portionId/edit.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
-  portionsQueryOptions,
+  portionsQueryKey,
   portionByIdQueryOptions,
   updatePortionMutationOptions,
 } from "@/queries/portion";
@@ -75,7 +75,7 @@ function UpdatePortionForm({ portionId, initialValues }: UpdatePortionFormProps)
 
       try {
         await updateMutation.mutateAsync(payload);
-        void queryClient.invalidateQueries({ queryKey: portionsQueryOptions.queryKey });
+        void queryClient.invalidateQueries({ queryKey: portionsQueryKey });
         void queryClient.invalidateQueries({ queryKey: ["portion", portionId] });
 
         toast.success("Portion updated.", {

--- a/apps/web/src/routes/portions/create.tsx
+++ b/apps/web/src/routes/portions/create.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { portionsMutationOptions, portionsQueryOptions } from "@/queries/portion";
+import { portionsMutationOptions, portionsQueryKey } from "@/queries/portion";
 import { Button } from "@/components/ui/button";
 import { useForm } from "@tanstack/react-form";
 import { Field, FieldContent, FieldGroup, FieldLabel, FieldTitle } from "@/components/ui/field";
@@ -31,7 +31,7 @@ function CreatePortion() {
 
       try {
         await mutation.mutateAsync(payload);
-        void queryClient.invalidateQueries({ queryKey: portionsQueryOptions.queryKey });
+        void queryClient.invalidateQueries({ queryKey: portionsQueryKey });
         toast.success("Portion created.", {
           position: "bottom-center",
         });

--- a/apps/web/src/routes/portions/index.tsx
+++ b/apps/web/src/routes/portions/index.tsx
@@ -7,6 +7,13 @@ import { Bean, CookingPot, Droplets, Drumstick, Leaf, Plus, Soup, Wheat } from "
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardAction } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { formatDistanceToNowStrict } from "date-fns";
 import { Route as createRoute } from "@/routes/portions/create";
 import { Route as editRoute } from "@/routes/portions/$portionId/edit";
@@ -14,8 +21,18 @@ import { Route as editRoute } from "@/routes/portions/$portionId/edit";
 import { cn } from "@/lib/utils";
 
 export const Route = createFileRoute("/portions/")({
-  loader: ({ context: { queryClient } }) =>
-    queryClient.ensureQueryData(portionsQueryOptions).catch(() => {}),
+  validateSearch: (search) => {
+    const sort = typeof search.sort === "string" ? search.sort : undefined;
+    const order = typeof search.order === "string" ? search.order : undefined;
+
+    return {
+      sort: sortFields.includes(sort as SortField) ? (sort as SortField) : undefined,
+      order: sortOrders.includes(order as SortOrder) ? (order as SortOrder) : undefined,
+    };
+  },
+  loaderDeps: ({ search }) => search,
+  loader: ({ context: { queryClient }, deps }) =>
+    queryClient.ensureQueryData(portionsQueryOptions(deps)).catch(() => {}),
   component: PortionsPage,
 });
 
@@ -28,60 +45,75 @@ type InventoryTile = {
 };
 
 type PortionType = Portion["type"];
+type SortField = "name" | "quantity" | "prepared_at";
+type SortOrder = "asc" | "desc";
+type SortOptionValue = `${SortField}-${SortOrder}`;
+
+const sortFields: SortField[] = ["prepared_at", "name", "quantity"];
+const sortOrders: SortOrder[] = ["desc", "asc"];
+
+const sortOptionLabels: Record<SortOptionValue, string> = {
+  "prepared_at-desc": "Prepared: Newest",
+  "prepared_at-asc": "Prepared: Oldest",
+  "name-asc": "Name: A-Z",
+  "name-desc": "Name: Z-A",
+  "quantity-asc": "Quantity: Low-High",
+  "quantity-desc": "Quantity: High-Low",
+};
 
 const inventoryTiles = {
   protein: {
     label: "Protein",
-    bgClass: "bg-secondary-fixed-dim/25 dark:bg-secondary-fixed-dim/20",
+    bgClass: "bg-card",
     iconBadgeClass: "bg-secondary-fixed-dim/45 dark:bg-secondary-fixed-dim/35",
     qtyBadgeClass: "bg-secondary-fixed-dim/30 text-foreground/80 dark:bg-secondary-fixed-dim/25",
     icon: Drumstick,
   },
   legume: {
     label: "Legume",
-    bgClass: "bg-primary-dim/22 dark:bg-primary-dim/16",
+    bgClass: "bg-card",
     iconBadgeClass: "bg-primary-dim/40 dark:bg-primary-dim/28",
     qtyBadgeClass: "bg-white text-foreground/80 dark:bg-primary-dim/20",
     icon: Bean,
   },
   vegetable: {
     label: "Veggie",
-    bgClass: "bg-primary-fixed-dim/25 dark:bg-primary-fixed-dim/20",
+    bgClass: "bg-card",
     iconBadgeClass: "bg-primary-fixed-dim/45 dark:bg-primary-fixed-dim/35",
     qtyBadgeClass: "bg-primary-fixed-dim/30 text-foreground/80 dark:bg-primary-fixed-dim/25",
     icon: Leaf,
   },
   carb: {
     label: "Carb",
-    bgClass: "bg-tertiary-fixed-dim/25 dark:bg-tertiary-fixed-dim/20",
+    bgClass: "bg-card",
     iconBadgeClass: "bg-tertiary-fixed-dim/45 dark:bg-tertiary-fixed-dim/35",
     qtyBadgeClass: "bg-tertiary-fixed-dim/30 text-foreground/80 dark:bg-tertiary-fixed-dim/25",
     icon: Wheat,
   },
   fat: {
     label: "Fat",
-    bgClass: "bg-accent/20 dark:bg-accent/16",
+    bgClass: "bg-card",
     iconBadgeClass: "bg-accent/40 dark:bg-accent/30",
     qtyBadgeClass: "bg-accent/25 text-foreground/80 dark:bg-accent/20",
     icon: Droplets,
   },
   sauce: {
     label: "Sauce",
-    bgClass: "bg-accent/20 dark:bg-accent/16",
+    bgClass: "bg-card",
     iconBadgeClass: "bg-accent/40 dark:bg-accent/30",
     qtyBadgeClass: "bg-accent/25 text-foreground/80 dark:bg-accent/20",
     icon: Droplets,
   },
   soup: {
     label: "Soup",
-    bgClass: "bg-accent/20 dark:bg-accent/16",
+    bgClass: "bg-card",
     iconBadgeClass: "bg-accent/40 dark:bg-accent/30",
     qtyBadgeClass: "bg-accent/25 text-foreground/80 dark:bg-accent/20",
     icon: Soup,
   },
   other: {
     label: "Other",
-    bgClass: "bg-surface-container-high dark:bg-surface-container-low",
+    bgClass: "bg-card",
     iconBadgeClass: "bg-surface-container-highest dark:bg-surface-bright/35",
     qtyBadgeClass: "bg-surface-container-highest text-foreground/80 dark:bg-surface-bright/30",
     icon: CookingPot,
@@ -89,11 +121,18 @@ const inventoryTiles = {
 } satisfies Record<PortionType, InventoryTile>;
 
 function PortionsPage() {
-  const { data, isError, isPending } = useQuery(portionsQueryOptions);
+  const search = Route.useSearch();
+  const navigate = Route.useNavigate();
+
+  const { data, isError, isPending } = useQuery(portionsQueryOptions(search));
+
+  const selectedSort = search.sort ?? "prepared_at";
+  const selectedOrder = search.order ?? (selectedSort === "name" ? "asc" : "desc");
+  const selectedSortValue = `${selectedSort}-${selectedOrder}` as SortOptionValue;
 
   return (
-    <main className="mx-auto flex w-full max-w-4xl flex-col px-4 py-6 pb-28 sm:px-6 md:px-8 md:py-8 md:pb-14">
-      <h1 className="text-3xl font-semibold tracking-[-0.02em] text-foreground md:text-[2.15rem] mb-5">
+    <main className="mx-auto flex w-full max-w-4xl flex-col px-4 py-6 pb-28 sm:px-6 md:px-8 md:py-8 md:pb-14 xl:max-w-6xl">
+      <h1 className="mb-5 text-2xl font-semibold tracking-[-0.02em] text-foreground md:text-[1.95rem]">
         Pantry Inventory
       </h1>
 
@@ -107,7 +146,35 @@ function PortionsPage() {
         <p className="text-sm tracking-[0.01em] text-on-surface-variant">Loading inventory...</p>
       )}
 
-      <div className="grid grid-cols-2 gap-2.5 md:grid-cols-3 md:gap-3">
+      <div className="mb-4 flex justify-end md:mb-5">
+        <Select
+          value={selectedSortValue}
+          onValueChange={(value) => {
+            const [sort, order] = value.split("-") as [SortField, SortOrder];
+
+            navigate({
+              search: (prev) => ({
+                ...prev,
+                sort,
+                order,
+              }),
+            });
+          }}
+        >
+          <SelectTrigger size="sm" className="w-full min-w-0 md:w-[220px]">
+            <SelectValue placeholder="Sort inventory" />
+          </SelectTrigger>
+          <SelectContent position="popper" side="bottom" sideOffset={8} align="start">
+            {Object.entries(sortOptionLabels).map(([value, label]) => (
+              <SelectItem key={value} value={value}>
+                {label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="grid grid-cols-2 items-stretch gap-2.5 md:grid-cols-3 md:gap-3 lg:grid-cols-4 xl:gap-3.5">
         {data &&
           data.map((portion) => {
             const tile = inventoryTiles[portion.type];
@@ -118,34 +185,48 @@ function PortionsPage() {
                 key={portion.id}
                 to={editRoute.to}
                 params={{ portionId: portion.id }}
-                className="rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                className="h-full rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               >
                 <Card
-                  className="gap-3 transition-shadow duration-150 hover:shadow-md hover:shadow-black/5 hover:ring-1 hover:ring-border/60"
+                  className={cn(
+                    "h-full min-h-44 gap-2 transition-shadow duration-150 hover:shadow-md hover:shadow-black/5 hover:ring-1 hover:ring-border/60 md:min-h-48 md:gap-2.5 lg:min-h-40 lg:gap-2",
+                    tile.bgClass,
+                  )}
                   size="sm"
                 >
-                  <CardHeader>
+                  <CardHeader className="lg:px-3 lg:gap-1.5">
                     <CardTitle
                       className={cn(
-                        "inline-flex size-11 items-center justify-center rounded-xl",
+                        "inline-flex size-10 items-center justify-center rounded-lg md:size-11 md:rounded-xl",
                         tile.iconBadgeClass,
                       )}
                     >
-                      <Icon className="size-4 text-foreground/75" aria-hidden="true" />
+                      <Icon
+                        className="size-4 text-foreground/75 md:size-[1.125rem]"
+                        aria-hidden="true"
+                      />
                     </CardTitle>
-                    <CardAction className="gap-1 flex flex-wrap justify-end">
-                      <Badge variant="outline">{portion.quantity} qty</Badge>
+                    <CardAction className="flex flex-wrap justify-end gap-1">
+                      <Badge
+                        variant="outline"
+                        className={cn(
+                          "h-5 px-2 text-[0.7rem] font-semibold tracking-[0.01em] md:h-6 md:text-xs",
+                          tile.qtyBadgeClass,
+                        )}
+                      >
+                        {portion.quantity} qty
+                      </Badge>
                     </CardAction>
                   </CardHeader>
 
-                  <CardContent>
-                    <p className="text-xs font-semibold uppercase tracking-[0.12em] text-foreground/65">
+                  <CardContent className="flex flex-1 flex-col lg:px-3">
+                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.12em] text-foreground/65 md:text-[0.72rem] md:tracking-[0.14em]">
                       {tile.label}
                     </p>
-                    <h2 className="mt-1 text-xl font-semibold leading-tight tracking-[-0.02em] text-foreground">
+                    <h2 className="mt-1 min-h-[2.45em] text-[0.97rem] font-semibold leading-tight tracking-[-0.02em] text-foreground line-clamp-2 md:text-base lg:min-h-[2.2em] lg:text-[0.95rem]">
                       {portion.name}
                     </h2>
-                    <p className="text-xs mt-1">
+                    <p className="mt-auto pt-1 text-[0.72rem] text-on-surface-variant md:pt-1.5 md:text-xs lg:pt-1 lg:text-[0.72rem]">
                       {formatDistanceToNowStrict(new Date(portion.prepared_at), {
                         addSuffix: true,
                       })}

--- a/apps/web/src/routes/portions/index.tsx
+++ b/apps/web/src/routes/portions/index.tsx
@@ -151,6 +151,7 @@ function PortionsPage() {
           value={selectedSortValue}
           onValueChange={(value) => {
             const separatorIndex = value.lastIndexOf("-");
+            if (separatorIndex === -1) return;
             const sort = value.slice(0, separatorIndex) as SortField;
             const order = value.slice(separatorIndex + 1) as SortOrder;
 

--- a/apps/web/src/routes/portions/index.tsx
+++ b/apps/web/src/routes/portions/index.tsx
@@ -150,7 +150,9 @@ function PortionsPage() {
         <Select
           value={selectedSortValue}
           onValueChange={(value) => {
-            const [sort, order] = value.split("-") as [SortField, SortOrder];
+            const separatorIndex = value.lastIndexOf("-");
+            const sort = value.slice(0, separatorIndex) as SortField;
+            const order = value.slice(separatorIndex + 1) as SortOrder;
 
             navigate({
               search: (prev) => ({

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "cube-prep",


### PR DESCRIPTION
- [x] Fix critical bug: use `lastIndexOf("-")` to correctly parse `prepared_at-desc`/`prepared_at-asc` sort values (the old `split("-")` gave `"prepared"` + `"at"` instead of `"prepared_at"` + `"desc"`)
- [x] Add guard: early return when no hyphen separator is found (defensive coding)
- [x] Remove dead code: `position === "popper" && ""` no-op in `SelectContent` viewport class
- [x] TypeScript type-check passes with no errors